### PR TITLE
CL PoC: simple transfer

### DIFF
--- a/goas/cl/cl/src/balance.rs
+++ b/goas/cl/cl/src/balance.rs
@@ -23,11 +23,8 @@ impl Balance {
 	// So we use the generator point as a stand in for the unit point.
 	//
 	// TAI: we can optimize this further from `0*G + r*H` to just `r*H` to save a point scalar mult + point addition.
-        Self(balance(
-            0,
-            curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT,
-            blinding.0,
-        ))
+	let unit = curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+        Self(balance(0, unit, blinding.0))
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {

--- a/goas/cl/cl/src/balance.rs
+++ b/goas/cl/cl/src/balance.rs
@@ -17,6 +17,15 @@ pub struct Balance(pub RistrettoPoint);
 pub struct BalanceWitness(pub Scalar);
 
 impl Balance {
+    /// A commitment to zero, blinded by the provided balance witness
+    pub fn zero(blinding: BalanceWitness) -> Self {
+        Self(balance(
+            0,
+            curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT,
+            blinding.0,
+        ))
+    }
+
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.compress().to_bytes()
     }

--- a/goas/cl/cl/src/balance.rs
+++ b/goas/cl/cl/src/balance.rs
@@ -19,6 +19,10 @@ pub struct BalanceWitness(pub Scalar);
 impl Balance {
     /// A commitment to zero, blinded by the provided balance witness
     pub fn zero(blinding: BalanceWitness) -> Self {
+	// Since, balance commitments are `value * UnitPoint + blinding * H`, when value=0, the commmitment is unitless.
+	// So we use the generator point as a stand in for the unit point.
+	//
+	// TAI: we can optimize this further from `0*G + r*H` to just `r*H` to save a point scalar mult + point addition.
         Self(balance(
             0,
             curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT,

--- a/goas/cl/cl/src/bundle.rs
+++ b/goas/cl/cl/src/bundle.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use curve25519_dalek::{constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint};
-
-use crate::{partial_tx::PartialTx, BalanceWitness};
+use crate::{partial_tx::PartialTx, Balance, BalanceWitness};
 
 /// The transaction bundle is a collection of partial transactions.
 /// The goal in bundling transactions is to produce a set of partial transactions
@@ -19,20 +17,20 @@ pub struct BundleWitness {
 }
 
 impl Bundle {
-    pub fn balance(&self) -> RistrettoPoint {
-        self.partials.iter().map(|ptx| ptx.balance()).sum()
+    pub fn balance(&self) -> Balance {
+        Balance(self.partials.iter().map(|ptx| ptx.balance().0).sum())
     }
 
     pub fn is_balanced(&self, witness: BalanceWitness) -> bool {
-        self.balance() == crate::balance::balance(0, RISTRETTO_BASEPOINT_POINT, witness.0)
+        self.balance() == Balance::zero(witness)
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::{
-        crypto::hash_to_curve, input::InputWitness, note::NoteWitness, nullifier::NullifierSecret,
-        output::OutputWitness, partial_tx::PartialTxWitness,
+        input::InputWitness, note::NoteWitness, nullifier::NullifierSecret, output::OutputWitness,
+        partial_tx::PartialTxWitness,
     };
 
     use super::*;
@@ -57,8 +55,8 @@ mod test {
             OutputWitness::random(NoteWitness::basic(4840, "CRV"), nf_c.commit(), &mut rng);
 
         let ptx_unbalanced = PartialTxWitness {
-            inputs: vec![nmo_10_in.clone(), eth_23_in.clone()],
-            outputs: vec![crv_4840_out.clone()],
+            inputs: vec![nmo_10_in, eth_23_in],
+            outputs: vec![crv_4840_out],
         };
 
         let bundle_witness = BundleWitness {
@@ -70,22 +68,14 @@ mod test {
         };
 
         let mut bundle = Bundle {
-            partials: vec![PartialTx::from_witness(ptx_unbalanced)],
+            partials: vec![ptx_unbalanced.commit()],
         };
 
         assert!(!bundle.is_balanced(bundle_witness.balance_blinding));
         assert_eq!(
-            bundle.balance(),
-            crate::balance::balance(4840, hash_to_curve(b"CRV"), crv_4840_out.balance_blinding.0)
-                - (crate::balance::balance(
-                    10,
-                    hash_to_curve(b"NMO"),
-                    nmo_10_in.balance_blinding.0
-                ) + crate::balance::balance(
-                    23,
-                    hash_to_curve(b"ETH"),
-                    eth_23_in.balance_blinding.0
-                ))
+            bundle.balance().0,
+            crv_4840_out.commit().balance.0
+                - (nmo_10_in.commit().balance.0 + eth_23_in.commit().balance.0)
         );
 
         let crv_4840_in = InputWitness::random(crv_4840_out, nf_c, &mut rng);
@@ -100,12 +90,13 @@ mod test {
             &mut rng,
         );
 
-        bundle
-            .partials
-            .push(PartialTx::from_witness(PartialTxWitness {
-                inputs: vec![crv_4840_in.clone()],
-                outputs: vec![nmo_10_out.clone(), eth_23_out.clone()],
-            }));
+        bundle.partials.push(
+            PartialTxWitness {
+                inputs: vec![crv_4840_in],
+                outputs: vec![nmo_10_out, eth_23_out],
+            }
+            .commit(),
+        );
 
         let witness = BundleWitness {
             balance_blinding: BalanceWitness::new(
@@ -116,15 +107,6 @@ mod test {
                     + eth_23_out.balance_blinding.0,
             ),
         };
-
-        assert_eq!(
-            bundle.balance(),
-            crate::balance::balance(
-                0,
-                curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT,
-                witness.balance_blinding.0
-            )
-        );
 
         assert!(bundle.is_balanced(witness.balance_blinding));
     }

--- a/goas/cl/cl/src/bundle.rs
+++ b/goas/cl/cl/src/bundle.rs
@@ -11,7 +11,7 @@ pub struct Bundle {
     pub partials: Vec<PartialTx>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BundleWitness {
     pub balance_blinding: BalanceWitness,
 }

--- a/goas/cl/cl/src/input.rs
+++ b/goas/cl/cl/src/input.rs
@@ -21,7 +21,6 @@ pub struct Input {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InputWitness {
     pub note: NoteWitness,
-    pub utxo_balance_blinding: BalanceWitness,
     pub balance_blinding: BalanceWitness,
     pub nf_sk: NullifierSecret,
     pub nonce: NullifierNonce,
@@ -36,7 +35,6 @@ impl InputWitness {
         assert_eq!(nf_sk.commit(), output.nf_pk);
         Self {
             note: output.note,
-            utxo_balance_blinding: output.balance_blinding,
             balance_blinding: BalanceWitness::random(&mut rng),
             nf_sk,
             nonce: output.nonce,
@@ -55,13 +53,8 @@ impl InputWitness {
         }
     }
 
-    pub fn to_output(&self) -> crate::OutputWitness {
-        crate::OutputWitness {
-            note: self.note,
-            balance_blinding: self.utxo_balance_blinding,
-            nf_pk: self.nf_sk.commit(),
-            nonce: self.nonce,
-        }
+    pub fn note_commitment(&self) -> crate::NoteCommitment {
+	self.note.commit(self.nf_sk.commit(), self.nonce)
     }
 }
 

--- a/goas/cl/cl/src/note.rs
+++ b/goas/cl/cl/src/note.rs
@@ -40,22 +40,26 @@ pub struct NoteWitness {
 }
 
 impl NoteWitness {
-    pub fn new(value: u64, unit: impl Into<String>, state: [u8; 32]) -> Self {
+    pub fn new(
+        value: u64,
+        unit: impl Into<String>,
+        death_constraint: [u8; 32],
+        state: [u8; 32],
+    ) -> Self {
         Self {
             value,
             unit: unit_point(&unit.into()),
-            death_constraint: [0u8; 32],
+            death_constraint,
             state,
         }
     }
 
     pub fn basic(value: u64, unit: impl Into<String>) -> Self {
-        Self {
-            value,
-            unit: unit_point(&unit.into()),
-            death_constraint: [0u8; 32],
-            state: [0u8; 32],
-        }
+        Self::new(value, unit, [0u8; 32], [0u8; 32])
+    }
+
+    pub fn stateless(value: u64, unit: impl Into<String>, death_constraint: [u8; 32]) -> Self {
+        Self::new(value, unit, death_constraint, [0u8; 32])
     }
 
     pub fn commit(&self, nf_pk: NullifierCommitment, nonce: NullifierNonce) -> NoteCommitment {

--- a/goas/cl/cl/src/note.rs
+++ b/goas/cl/cl/src/note.rs
@@ -103,7 +103,7 @@ mod test {
         let nf_pk = NullifierSecret::random(&mut rng).commit();
         let nf_nonce = NullifierNonce::random(&mut rng);
 
-        let reference_note = NoteWitness::new(32, "NMO", [0u8; 32]);
+        let reference_note = NoteWitness::basic(32, "NMO");
 
         // different notes under same nullifier produce different commitments
         let mutation_tests = [

--- a/goas/cl/cl/src/output.rs
+++ b/goas/cl/cl/src/output.rs
@@ -107,23 +107,23 @@ mod test {
         let wrong_witnesses = [
             OutputWitness {
                 note: NoteWitness::basic(11, "NMO"),
-                ..witness.clone()
+                ..witness
             },
             OutputWitness {
                 note: NoteWitness::basic(10, "ETH"),
-                ..witness.clone()
+                ..witness
             },
             OutputWitness {
                 balance_blinding: BalanceWitness::random(&mut rng),
-                ..witness.clone()
+                ..witness
             },
             OutputWitness {
                 nf_pk: NullifierSecret::random(&mut rng).commit(),
-                ..witness.clone()
+                ..witness
             },
             OutputWitness {
                 nonce: NullifierNonce::random(&mut rng),
-                ..witness.clone()
+                ..witness
             },
         ];
 

--- a/goas/cl/cl/src/partial_tx.rs
+++ b/goas/cl/cl/src/partial_tx.rs
@@ -54,13 +54,6 @@ impl PartialTxWitness {
         }
     }
 
-    pub fn balance_delta(&self) -> i128 {
-        let in_sum: i128 = self.inputs.iter().map(|i| i.note.value as i128).sum();
-        let out_sum: i128 = self.outputs.iter().map(|o| o.note.value as i128).sum();
-
-        out_sum - in_sum
-    }
-
     pub fn balance_blinding(&self) -> BalanceWitness {
         let in_sum: Scalar = self.inputs.iter().map(|i| i.balance_blinding.0).sum();
         let out_sum: Scalar = self.outputs.iter().map(|o| o.balance_blinding.0).sum();

--- a/goas/cl/cl/tests/simple_transfer.rs
+++ b/goas/cl/cl/tests/simple_transfer.rs
@@ -1,0 +1,41 @@
+use rand_core::CryptoRngCore;
+
+fn receive_utxo(
+    note: cl::NoteWitness,
+    nf_pk: cl::NullifierCommitment,
+    rng: impl CryptoRngCore,
+) -> cl::OutputWitness {
+    cl::OutputWitness::random(note, nf_pk, rng)
+}
+
+#[test]
+fn test_simple_transfer() {
+    let mut rng = rand::thread_rng();
+
+    let sender_nf_sk = cl::NullifierSecret::random(&mut rng);
+    let sender_nf_pk = sender_nf_sk.commit();
+
+    let recipient_nf_pk = cl::NullifierSecret::random(&mut rng).commit();
+
+    // Assume the sender has received an unspent output from somewhere
+    let utxo = receive_utxo(cl::NoteWitness::basic(10, "NMO"), sender_nf_pk, &mut rng);
+
+    // and wants to send 8 NMO to some recipient and return 2 NMO to itself.
+    let recipient_output =
+        cl::OutputWitness::random(cl::NoteWitness::basic(8, "NMO"), recipient_nf_pk, &mut rng);
+    let change_output =
+        cl::OutputWitness::random(cl::NoteWitness::basic(2, "NMO"), sender_nf_pk, &mut rng);
+
+    let ptx_witness = cl::PartialTxWitness {
+        inputs: vec![cl::InputWitness::random(utxo, sender_nf_sk, &mut rng)],
+        outputs: vec![recipient_output, change_output],
+    };
+
+    let ptx = ptx_witness.commit();
+
+    let bundle = cl::Bundle {
+        partials: vec![ptx],
+    };
+
+    assert!(bundle.is_balanced(ptx_witness.balance_blinding()))
+}

--- a/goas/cl/ledger/Cargo.toml
+++ b/goas/cl/ledger/Cargo.toml
@@ -10,4 +10,5 @@ nomos_cl_risc0_proofs = { path = "../risc0_proofs" }
 risc0-zkvm = { version = "1.0", features = ["prove", "metal"] }
 risc0-groth16 = { version = "1.0" }
 rand = "0.8.5"
+rand_core = "0.6.0"
 thiserror = "1.0.62"

--- a/goas/cl/ledger/src/bundle.rs
+++ b/goas/cl/ledger/src/bundle.rs
@@ -6,12 +6,12 @@ pub struct ProvedBundle {
 }
 
 impl ProvedBundle {
-    pub fn prove(bundle: &cl::Bundle, balance_witness: &cl::BalanceWitness) -> Self {
+    pub fn prove(bundle: &cl::Bundle, bundle_witness: &cl::BundleWitness) -> Self {
         // need to show that bundle is balanced.
         // i.e. the sum of ptx balances is 0
 
         let env = risc0_zkvm::ExecutorEnv::builder()
-            .write(&balance_witness)
+            .write(&bundle_witness)
             .unwrap()
             .build()
             .unwrap();

--- a/goas/cl/ledger/src/bundle.rs
+++ b/goas/cl/ledger/src/bundle.rs
@@ -1,0 +1,57 @@
+use crate::error::Result;
+
+pub struct ProvedBundle {
+    pub bundle: cl::Bundle,
+    pub risc0_receipt: risc0_zkvm::Receipt,
+}
+
+impl ProvedBundle {
+    pub fn prove(bundle: &cl::Bundle, balance_witness: &cl::BalanceWitness) -> Self {
+        // need to show that bundle is balanced.
+        // i.e. the sum of ptx balances is 0
+
+        let env = risc0_zkvm::ExecutorEnv::builder()
+            .write(&balance_witness)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let prover = risc0_zkvm::default_prover();
+
+        let start_t = std::time::Instant::now();
+
+        let opts = risc0_zkvm::ProverOpts::succinct();
+        let prove_info = prover
+            .prove_with_opts(env, nomos_cl_risc0_proofs::BUNDLE_ELF, &opts)
+            .unwrap();
+
+        println!(
+            "STARK 'bundle' prover time: {:.2?}, total_cycles: {}",
+            start_t.elapsed(),
+            prove_info.stats.total_cycles
+        );
+
+        let receipt = prove_info.receipt;
+
+        Self {
+            bundle: bundle.clone(),
+            risc0_receipt: receipt,
+        }
+    }
+
+    pub fn public(&self) -> Result<cl::Balance> {
+        Ok(self.risc0_receipt.journal.decode()?)
+    }
+
+    pub fn verify(&self) -> bool {
+        let Ok(zero_commitment) = self.public() else {
+            return false;
+        };
+
+        self.bundle.balance() == zero_commitment
+            && self
+                .risc0_receipt
+                .verify(nomos_cl_risc0_proofs::BUNDLE_ID)
+                .is_ok()
+    }
+}

--- a/goas/cl/ledger/src/input.rs
+++ b/goas/cl/ledger/src/input.rs
@@ -77,11 +77,6 @@ impl ProvedInput {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct InputProof {}
-
-impl InputProof {}
-
 fn note_commitment_leaves(note_commitments: &[cl::NoteCommitment]) -> [[u8; 32]; MAX_NOTE_COMMS] {
     let note_comm_bytes = Vec::from_iter(note_commitments.iter().map(|c| c.as_bytes().to_vec()));
     let cm_leaves = cl::merkle::padded_leaves::<MAX_NOTE_COMMS>(&note_comm_bytes);

--- a/goas/cl/ledger/src/input.rs
+++ b/goas/cl/ledger/src/input.rs
@@ -11,7 +11,7 @@ pub struct ProvedInput {
 
 impl ProvedInput {
     pub fn prove(input: &cl::InputWitness, note_commitments: &[cl::NoteCommitment]) -> Self {
-        let output_cm = input.to_output().commit_note();
+        let output_cm = input.note_commitment();
 
         let cm_leaves = note_commitment_leaves(note_commitments);
         let cm_idx = note_commitments
@@ -95,13 +95,12 @@ mod test {
 
         let input = cl::InputWitness {
             note: cl::NoteWitness::basic(32, "NMO"),
-            utxo_balance_blinding: cl::BalanceWitness::random(&mut rng),
             balance_blinding: cl::BalanceWitness::random(&mut rng),
             nf_sk: cl::NullifierSecret::random(&mut rng),
             nonce: cl::NullifierNonce::random(&mut rng),
         };
 
-        let notes = vec![input.to_output().commit_note()];
+        let notes = vec![input.note_commitment()];
 
         let mut proved_input = ProvedInput::prove(&input, &notes);
 

--- a/goas/cl/ledger/src/input.rs
+++ b/goas/cl/ledger/src/input.rs
@@ -96,7 +96,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_input_nullifier_prover() {
+    fn test_input_prover() {
         let mut rng = thread_rng();
 
         let input = cl::InputWitness {

--- a/goas/cl/ledger/src/lib.rs
+++ b/goas/cl/ledger/src/lib.rs
@@ -1,2 +1,6 @@
+// pub mod death_constraint;
+pub mod bundle;
 pub mod error;
 pub mod input;
+pub mod output;
+pub mod partial_tx;

--- a/goas/cl/ledger/src/output.rs
+++ b/goas/cl/ledger/src/output.rs
@@ -1,0 +1,103 @@
+use crate::error::Result;
+
+pub struct ProvedOutput {
+    pub output: cl::Output,
+    pub risc0_receipt: risc0_zkvm::Receipt,
+}
+
+impl ProvedOutput {
+    pub fn prove(witness: &cl::OutputWitness) -> Self {
+        let env = risc0_zkvm::ExecutorEnv::builder()
+            .write(&witness)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let prover = risc0_zkvm::default_prover();
+
+        let start_t = std::time::Instant::now();
+
+        let opts = risc0_zkvm::ProverOpts::succinct();
+        let prove_info = prover
+            .prove_with_opts(env, nomos_cl_risc0_proofs::OUTPUT_ELF, &opts)
+            .unwrap();
+
+        println!(
+            "STARK 'output' prover time: {:.2?}, total_cycles: {}",
+            start_t.elapsed(),
+            prove_info.stats.total_cycles
+        );
+
+        let receipt = prove_info.receipt;
+
+        Self {
+            output: witness.commit(),
+            risc0_receipt: receipt,
+        }
+    }
+
+    pub fn public(&self) -> Result<cl::Output> {
+        Ok(self.risc0_receipt.journal.decode()?)
+    }
+
+    pub fn verify(&self) -> bool {
+        let Ok(output_commitments) = self.public() else {
+            return false;
+        };
+
+        self.output == output_commitments
+            && self
+                .risc0_receipt
+                .verify(nomos_cl_risc0_proofs::OUTPUT_ID)
+                .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::thread_rng;
+
+    use super::*;
+
+    #[test]
+    fn test_output_prover() {
+        let mut rng = thread_rng();
+
+        let output = cl::OutputWitness {
+            note: cl::NoteWitness::basic(32, "NMO"),
+            balance_blinding: cl::BalanceWitness::random(&mut rng),
+            nf_pk: cl::NullifierSecret::random(&mut rng).commit(),
+            nonce: cl::NullifierNonce::random(&mut rng),
+        };
+
+        let mut proved_output = ProvedOutput::prove(&output);
+
+        let expected_output_cm = output.commit();
+
+        assert_eq!(proved_output.output, expected_output_cm);
+        assert!(proved_output.verify());
+
+        let wrong_output_cms = [
+            cl::Output {
+                note_comm: cl::NoteWitness::basic(100, "NMO").commit(
+                    cl::NullifierSecret::random(&mut rng).commit(),
+                    cl::NullifierNonce::random(&mut rng),
+                ),
+                ..expected_output_cm
+            },
+            cl::Output {
+                note_comm: cl::NoteWitness::basic(100, "NMO").commit(
+                    cl::NullifierSecret::random(&mut rng).commit(),
+                    cl::NullifierNonce::random(&mut rng),
+                ),
+                balance: cl::BalanceWitness::random(&mut rng)
+                    .commit(&cl::NoteWitness::basic(100, "NMO")),
+            },
+        ];
+
+        for wrong_output_cm in wrong_output_cms {
+            proved_output.output = wrong_output_cm;
+            assert!(!proved_output.verify());
+        }
+    }
+}

--- a/goas/cl/ledger/src/partial_tx.rs
+++ b/goas/cl/ledger/src/partial_tx.rs
@@ -1,0 +1,26 @@
+use crate::{input::ProvedInput, output::ProvedOutput};
+
+pub struct ProvedPartialTx {
+    pub inputs: Vec<ProvedInput>,
+    pub outputs: Vec<ProvedOutput>,
+}
+
+impl ProvedPartialTx {
+    pub fn prove(
+        ptx: &cl::PartialTxWitness,
+        note_commitments: &[cl::NoteCommitment],
+    ) -> ProvedPartialTx {
+        Self {
+            inputs: Vec::from_iter(
+                ptx.inputs
+                    .iter()
+                    .map(|i| ProvedInput::prove(i, note_commitments)),
+            ),
+            outputs: Vec::from_iter(ptx.outputs.iter().map(ProvedOutput::prove)),
+        }
+    }
+
+    pub fn verify(&self) -> bool {
+        self.inputs.iter().all(ProvedInput::verify) && self.outputs.iter().all(ProvedOutput::verify)
+    }
+}

--- a/goas/cl/ledger/tests/simple_transfer.rs
+++ b/goas/cl/ledger/tests/simple_transfer.rs
@@ -1,0 +1,49 @@
+use ledger::{bundle::ProvedBundle, partial_tx::ProvedPartialTx};
+use rand_core::CryptoRngCore;
+
+fn receive_utxo(
+    note: cl::NoteWitness,
+    nf_pk: cl::NullifierCommitment,
+    rng: impl CryptoRngCore,
+) -> cl::OutputWitness {
+    cl::OutputWitness::random(note, nf_pk, rng)
+}
+
+#[test]
+fn test_simple_transfer() {
+    let mut rng = rand::thread_rng();
+
+    let sender_nf_sk = cl::NullifierSecret::random(&mut rng);
+    let sender_nf_pk = sender_nf_sk.commit();
+
+    let recipient_nf_pk = cl::NullifierSecret::random(&mut rng).commit();
+
+    // Assume the sender has received an unspent output from somewhere
+    let utxo = receive_utxo(cl::NoteWitness::basic(10, "NMO"), sender_nf_pk, &mut rng);
+
+    let note_commitments = vec![utxo.commit_note()];
+
+    let input = cl::InputWitness::random(utxo, sender_nf_sk, &mut rng);
+
+    // and wants to send 8 NMO to some recipient and return 2 NMO to itself.
+    let recipient_output =
+        cl::OutputWitness::random(cl::NoteWitness::basic(8, "NMO"), recipient_nf_pk, &mut rng);
+    let change_output =
+        cl::OutputWitness::random(cl::NoteWitness::basic(2, "NMO"), sender_nf_pk, &mut rng);
+
+    let ptx_witness = cl::PartialTxWitness {
+        inputs: vec![input],
+        outputs: vec![recipient_output, change_output],
+    };
+
+    let proved_ptx = ProvedPartialTx::prove(&ptx_witness, &note_commitments);
+
+    assert!(proved_ptx.verify());
+
+    let bundle = cl::Bundle {
+        partials: vec![ptx_witness.commit()],
+    };
+
+    let proved_bundle = ProvedBundle::prove(&bundle, &ptx_witness.balance_blinding());
+    assert!(proved_bundle.verify());
+}

--- a/goas/cl/ledger/tests/simple_transfer.rs
+++ b/goas/cl/ledger/tests/simple_transfer.rs
@@ -1,6 +1,22 @@
 use ledger::{bundle::ProvedBundle, partial_tx::ProvedPartialTx};
 use rand_core::CryptoRngCore;
 
+struct User(cl::NullifierSecret);
+
+impl User {
+    fn random(mut rng: impl CryptoRngCore) -> Self {
+        Self(cl::NullifierSecret::random(&mut rng))
+    }
+
+    fn pk(&self) -> cl::NullifierCommitment {
+        self.0.commit()
+    }
+
+    fn sk(&self) -> cl::NullifierSecret {
+        self.0
+    }
+}
+
 fn receive_utxo(
     note: cl::NoteWitness,
     nf_pk: cl::NullifierCommitment,
@@ -13,37 +29,39 @@ fn receive_utxo(
 fn test_simple_transfer() {
     let mut rng = rand::thread_rng();
 
-    let sender_nf_sk = cl::NullifierSecret::random(&mut rng);
-    let sender_nf_pk = sender_nf_sk.commit();
+    // alice is sending 8 NMO to bob.
 
-    let recipient_nf_pk = cl::NullifierSecret::random(&mut rng).commit();
+    let alice = User::random(&mut rng);
+    let bob = User::random(&mut rng);
 
-    // Assume the sender has received an unspent output from somewhere
-    let utxo = receive_utxo(cl::NoteWitness::basic(10, "NMO"), sender_nf_pk, &mut rng);
+    // Alice has an unspent note worth 10 NMO
+    let utxo = receive_utxo(cl::NoteWitness::basic(10, "NMO"), alice.pk(), &mut rng);
+    let alices_input = cl::InputWitness::random(utxo, alice.sk(), &mut rng);
 
-    let note_commitments = vec![utxo.commit_note()];
+    // Alice wants to send 8 NMO to bob
+    let bobs_output =
+        cl::OutputWitness::random(cl::NoteWitness::basic(8, "NMO"), bob.pk(), &mut rng);
 
-    let input = cl::InputWitness::random(utxo, sender_nf_sk, &mut rng);
-
-    // and wants to send 8 NMO to some recipient and return 2 NMO to itself.
-    let recipient_output =
-        cl::OutputWitness::random(cl::NoteWitness::basic(8, "NMO"), recipient_nf_pk, &mut rng);
+    // .. and return the 2 NMO in change to herself.
     let change_output =
-        cl::OutputWitness::random(cl::NoteWitness::basic(2, "NMO"), sender_nf_pk, &mut rng);
+        cl::OutputWitness::random(cl::NoteWitness::basic(2, "NMO"), alice.pk(), &mut rng);
 
+    // Construct the ptx consuming Alices inputs and producing the two outputs.
     let ptx_witness = cl::PartialTxWitness {
-        inputs: vec![input],
-        outputs: vec![recipient_output, change_output],
+        inputs: vec![alices_input],
+        outputs: vec![bobs_output, change_output],
     };
 
+    // assume we only have one note commitment on chain for now ...
+    let note_commitments = vec![utxo.commit_note()];
     let proved_ptx = ProvedPartialTx::prove(&ptx_witness, &note_commitments);
 
-    assert!(proved_ptx.verify());
+    assert!(proved_ptx.verify()); // It's a valid ptx.
 
     let bundle = cl::Bundle {
         partials: vec![ptx_witness.commit()],
     };
 
     let proved_bundle = ProvedBundle::prove(&bundle, &ptx_witness.balance_blinding());
-    assert!(proved_bundle.verify());
+    assert!(proved_bundle.verify()); // The bundle is balanced.
 }

--- a/goas/cl/ledger/tests/simple_transfer.rs
+++ b/goas/cl/ledger/tests/simple_transfer.rs
@@ -62,6 +62,10 @@ fn test_simple_transfer() {
         partials: vec![ptx_witness.commit()],
     };
 
-    let proved_bundle = ProvedBundle::prove(&bundle, &ptx_witness.balance_blinding());
+    let bundle_witness = cl::BundleWitness {
+	balance_blinding: ptx_witness.balance_blinding(),
+    };
+
+    let proved_bundle = ProvedBundle::prove(&bundle, &bundle_witness);
     assert!(proved_bundle.verify()); // The bundle is balanced.
 }

--- a/goas/cl/proof_statements/src/death_constraint.rs
+++ b/goas/cl/proof_statements/src/death_constraint.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeathConstraintPublic {
-    pub cm_root: [u8; 32],
     pub nf: Nullifier,
     pub ptx_root: PtxRoot,
 }

--- a/goas/cl/proof_statements/src/lib.rs
+++ b/goas/cl/proof_statements/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod death_constraint;
 pub mod input;
-pub mod partial_tx;
 pub mod ptx;

--- a/goas/cl/proof_statements/src/lib.rs
+++ b/goas/cl/proof_statements/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod death_constraint;
 pub mod input;
+pub mod partial_tx;
 pub mod ptx;

--- a/goas/cl/proof_statements/src/ptx.rs
+++ b/goas/cl/proof_statements/src/ptx.rs
@@ -1,5 +1,6 @@
 use cl::{merkle, InputWitness, OutputWitness, PtxRoot};
 use serde::{Deserialize, Serialize};
+
 /// An input to a partial transaction
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PartialTxInputPrivate {

--- a/goas/cl/proof_statements/src/ptx.rs
+++ b/goas/cl/proof_statements/src/ptx.rs
@@ -16,7 +16,7 @@ impl PartialTxInputPrivate {
     }
 
     pub fn cm_root(&self) -> [u8; 32] {
-        let leaf = merkle::leaf(self.input.to_output().commit_note().as_bytes());
+        let leaf = merkle::leaf(self.input.note_commitment().as_bytes());
         merkle::path_root(leaf, &self.cm_path)
     }
 }

--- a/goas/cl/risc0_proofs/Cargo.toml
+++ b/goas/cl/risc0_proofs/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 risc0-build = { version = "1.0" }
 
 [package.metadata.risc0]
-methods = ["input"]
+methods = ["input", "output", "bundle", "death_constraint_nop"]
 

--- a/goas/cl/risc0_proofs/bundle/Cargo.toml
+++ b/goas/cl/risc0_proofs/bundle/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bundle"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+risc0-zkvm = { version = "1.0", default-features = false, features = ['std'] }
+serde = { version = "1.0", features = ["derive"] }
+cl = { path = "../../cl" }
+proof_statements = { path = "../../proof_statements" }
+
+
+[patch.crates-io]
+# add RISC Zero accelerator support for all downstream usages of the following crates.
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
+curve25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }

--- a/goas/cl/risc0_proofs/bundle/src/main.rs
+++ b/goas/cl/risc0_proofs/bundle/src/main.rs
@@ -11,7 +11,7 @@
 use risc0_zkvm::guest::env;
 
 fn main() {
-    let zero_witness: cl::BalanceWitness = env::read();
-    let zero_balance = cl::Balance::zero(zero_witness);
+    let bundle_witness: cl::BundleWitness = env::read();
+    let zero_balance = cl::Balance::zero(bundle_witness.balance_blinding);
     env::commit(&zero_balance);
 }

--- a/goas/cl/risc0_proofs/bundle/src/main.rs
+++ b/goas/cl/risc0_proofs/bundle/src/main.rs
@@ -1,0 +1,17 @@
+/// Bundle Proof
+///
+/// The bundle proof demonstrates that the set of partial transactions
+/// balance to zero. i.e. \sum inputs = \sum outputs.
+///
+/// This is done by proving knowledge of some blinding factor `r` s.t.
+///     \sum outputs - \sum input = 0*G + r*H
+///
+/// To avoid doing costly ECC in stark, we compute only the RHS in stark.
+/// The sums and equality is checked outside of stark during proof verification.
+use risc0_zkvm::guest::env;
+
+fn main() {
+    let zero_witness: cl::BalanceWitness = env::read();
+    let zero_balance = cl::Balance::zero(zero_witness);
+    env::commit(&zero_balance);
+}

--- a/goas/cl/risc0_proofs/death_constraint_nop/Cargo.toml
+++ b/goas/cl/risc0_proofs/death_constraint_nop/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "death_constraint_nop"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+risc0-zkvm = { version = "1.0", default-features = false, features = ['std'] }
+serde = { version = "1.0", features = ["derive"] }
+cl = { path = "../../cl" }
+proof_statements = { path = "../../proof_statements" }
+
+
+[patch.crates-io]
+# add RISC Zero accelerator support for all downstream usages of the following crates.
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
+curve25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }

--- a/goas/cl/risc0_proofs/death_constraint_nop/src/main.rs
+++ b/goas/cl/risc0_proofs/death_constraint_nop/src/main.rs
@@ -1,0 +1,8 @@
+/// Death Constraint No-op Proof
+use proof_statements::death_constraint::DeathConstraintPublic;
+use risc0_zkvm::guest::env;
+
+fn main() {
+    let public: DeathConstraintPublic = env::read();
+    env::commit(&public);
+}

--- a/goas/cl/risc0_proofs/input/src/main.rs
+++ b/goas/cl/risc0_proofs/input/src/main.rs
@@ -6,7 +6,7 @@ use risc0_zkvm::guest::env;
 fn main() {
     let secret: InputPrivate = env::read();
 
-    let out_cm = secret.input.to_output().commit_note();
+    let out_cm = secret.input.note_commitment();
     let cm_leaf = merkle::leaf(out_cm.as_bytes());
     let cm_root = merkle::path_root(cm_leaf, &secret.cm_path);
 

--- a/goas/cl/risc0_proofs/output/Cargo.toml
+++ b/goas/cl/risc0_proofs/output/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "output"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+risc0-zkvm = { version = "1.0", default-features = false, features = ['std'] }
+serde = { version = "1.0", features = ["derive"] }
+cl = { path = "../../cl" }
+proof_statements = { path = "../../proof_statements" }
+
+
+[patch.crates-io]
+# add RISC Zero accelerator support for all downstream usages of the following crates.
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
+curve25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.2-risczero.0" }

--- a/goas/cl/risc0_proofs/output/src/main.rs
+++ b/goas/cl/risc0_proofs/output/src/main.rs
@@ -1,0 +1,12 @@
+/// Output Proof
+///
+/// given randomness `r` and `note=(value, unit, ...)` prove that
+/// - balance = balance_commit(value, unit, r)
+/// - note_cm = note_commit(note)
+use risc0_zkvm::guest::env;
+
+fn main() {
+    let output: cl::OutputWitness = env::read();
+    let output_cm = output.commit();
+    env::commit(&output_cm);
+}

--- a/goas/zone/risc0_proofs/spend_zone_funds/src/main.rs
+++ b/goas/zone/risc0_proofs/spend_zone_funds/src/main.rs
@@ -18,7 +18,6 @@ fn main() {
         spend_event_state_path,
     } = env::read();
 
-    let cm_root = in_zone_funds.cm_root();
     let ptx_root = in_zone_funds.ptx_root();
     let nf = Nullifier::new(in_zone_funds.input.nf_sk, in_zone_funds.input.nonce);
     // check the zone funds note is the one in the spend event
@@ -78,7 +77,6 @@ fn main() {
     assert_eq!(spent_note.output.nf_pk, spend_event.to);
 
     env::commit(&DeathConstraintPublic {
-        cm_root,
         ptx_root,
         nf,
     });


### PR DESCRIPTION
The transfer scenario is defined in `/goas/cl/ledger/tests/simple_transfer.rs`

A user transfers a portion of a note to a recipient, and returns the change to themself.

This required:
1. Input proofs verifying nullifier and note commitments were valid
2. Output proofs verifying balances and note commitments are consistent
3. Bundle proofs verifying that a bundle of partial transactions balance to zero (i.e. $\sum inputs = \sum outputs$)

The whole scenario (proving and verifying the transfer) take just under 1 minute on an M2 macbook.