### PR TITLE
cl: ban zero valued outputs

### DIFF
--- a/goas/cl/ledger/src/bundle.rs
+++ b/goas/cl/ledger/src/bundle.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 pub struct ProvedBundle {
     pub bundle: cl::Bundle,
@@ -6,7 +6,7 @@ pub struct ProvedBundle {
 }
 
 impl ProvedBundle {
-    pub fn prove(bundle: &cl::Bundle, bundle_witness: &cl::BundleWitness) -> Self {
+    pub fn prove(bundle: &cl::Bundle, bundle_witness: &cl::BundleWitness) -> Result<Self> {
         // need to show that bundle is balanced.
         // i.e. the sum of ptx balances is 0
 
@@ -23,7 +23,7 @@ impl ProvedBundle {
         let opts = risc0_zkvm::ProverOpts::succinct();
         let prove_info = prover
             .prove_with_opts(env, nomos_cl_risc0_proofs::BUNDLE_ELF, &opts)
-            .unwrap();
+            .map_err(|_| Error::Risc0ProofFailed)?;
 
         println!(
             "STARK 'bundle' prover time: {:.2?}, total_cycles: {}",
@@ -33,10 +33,10 @@ impl ProvedBundle {
 
         let receipt = prove_info.receipt;
 
-        Self {
+        Ok(Self {
             bundle: bundle.clone(),
             risc0_receipt: receipt,
-        }
+        })
     }
 
     pub fn public(&self) -> Result<cl::Balance> {

--- a/goas/cl/ledger/src/error.rs
+++ b/goas/cl/ledger/src/error.rs
@@ -6,4 +6,6 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     #[error("risc0 failed to serde")]
     Risc0Serde(#[from] risc0_zkvm::serde::Error),
+    #[error("risc0 failed to prove execution of the zkvm")]
+    Risc0ProofFailed,
 }

--- a/goas/cl/ledger/tests/simple_transfer.rs
+++ b/goas/cl/ledger/tests/simple_transfer.rs
@@ -68,7 +68,7 @@ fn test_simple_transfer() {
 
     // assume we only have one note commitment on chain for now ...
     let note_commitments = vec![utxo.commit_note()];
-    let proved_ptx = ProvedPartialTx::prove(&ptx_witness, death_proofs, &note_commitments);
+    let proved_ptx = ProvedPartialTx::prove(&ptx_witness, death_proofs, &note_commitments).unwrap();
 
     assert!(proved_ptx.verify()); // It's a valid ptx.
 
@@ -80,6 +80,6 @@ fn test_simple_transfer() {
         balance_blinding: ptx_witness.balance_blinding(),
     };
 
-    let proved_bundle = ProvedBundle::prove(&bundle, &bundle_witness);
+    let proved_bundle = ProvedBundle::prove(&bundle, &bundle_witness).unwrap();
     assert!(proved_bundle.verify()); // The bundle is balanced.
 }

--- a/goas/cl/risc0_proofs/output/src/main.rs
+++ b/goas/cl/risc0_proofs/output/src/main.rs
@@ -7,6 +7,12 @@ use risc0_zkvm::guest::env;
 
 fn main() {
     let output: cl::OutputWitness = env::read();
+
+    // 0 does not contribute to balance, implications of this are unclear
+    // therefore out of an abundance of caution, we disallow these zero
+    // valued "dummy notes".
+    assert!(output.note.value > 0);
+
     let output_cm = output.commit();
     env::commit(&output_cm);
 }


### PR DESCRIPTION
implications of zero valued notes are unclear, so we'll ban them for now until we see a valid use-case.