### PR TITLE
goas: isolated executor proof tests

### DIFF
--- a/goas/atomic_asset_transfer/executor/src/lib.rs
+++ b/goas/atomic_asset_transfer/executor/src/lib.rs
@@ -232,7 +232,7 @@ mod tests {
 
         let bind = OutputWitness::public(
             NoteWitness::basic(32, *common::ZONE_CL_FUNDS_UNIT),
-            cl::NullifierNonce([0u8; 32]),
+            cl::NullifierNonce::random(&mut rng),
         );
 
         let mut alice = common::new_account(&mut rng);

--- a/goas/atomic_asset_transfer/executor/src/lib.rs
+++ b/goas/atomic_asset_transfer/executor/src/lib.rs
@@ -157,7 +157,7 @@ pub fn prove_zone_stf(
     ledger::DeathProof::from_risc0(goas_risc0_proofs::ZONE_STATE_ID, receipt)
 }
 
-pub fn prove_zone_fund_withdraw(
+pub fn prove_zone_fund_constraint(
     in_zone_funds: cl::PartialTxInputWitness,
     zone_note: cl::PartialTxOutputWitness,
     out_zone_state: &StateWitness,
@@ -286,6 +286,25 @@ mod tests {
 
         assert!(proof.verify(DeathConstraintPublic {
             nf: zone_start.state_input_witness().nullifier(),
+            ptx_root: ptx.commit().root(),
+        }))
+    }
+
+    #[test]
+    fn test_prove_zone_fund_constraint() {
+        let zone =
+            ZoneNotes::new_with_balances("ZONE", BTreeMap::from_iter([]), &mut rand::thread_rng());
+
+        let ptx = PartialTxWitness {
+            inputs: vec![zone.fund_input_witness()],
+            outputs: vec![zone.state_note],
+        };
+
+        let proof =
+            prove_zone_fund_constraint(ptx.input_witness(0), ptx.output_witness(0), &zone.state);
+
+        assert!(proof.verify(DeathConstraintPublic {
+            nf: zone.fund_input_witness().nullifier(),
             ptx_root: ptx.commit().root(),
         }))
     }

--- a/goas/atomic_asset_transfer/executor/tests/atomic_transfer.rs
+++ b/goas/atomic_asset_transfer/executor/tests/atomic_transfer.rs
@@ -111,7 +111,7 @@ fn test_atomic_transfer() {
         ),
         (
             zone_a_start.fund_input_witness().nullifier(),
-            executor::prove_zone_fund_withdraw(
+            executor::prove_zone_fund_constraint(
                 atomic_transfer_ptx.input_witness(2),  // input fund note
                 atomic_transfer_ptx.output_witness(0), // output state note
                 &zone_a_end.state,
@@ -129,7 +129,7 @@ fn test_atomic_transfer() {
         ),
         (
             zone_b_start.fund_input_witness().nullifier(),
-            executor::prove_zone_fund_withdraw(
+            executor::prove_zone_fund_constraint(
                 atomic_transfer_ptx.input_witness(4), // input fund note (input #1)
                 atomic_transfer_ptx.output_witness(2), // output state note (output #0)
                 &zone_b_end.state,

--- a/goas/atomic_asset_transfer/executor/tests/withdraw_ptx.rs
+++ b/goas/atomic_asset_transfer/executor/tests/withdraw_ptx.rs
@@ -73,7 +73,7 @@ fn test_withdrawal() {
         ),
         (
             zone_start.fund_input_witness().nullifier(),
-            executor::prove_zone_fund_withdraw(
+            executor::prove_zone_fund_constraint(
                 withdraw_ptx.input_witness(1),  // input fund note (input #1)
                 withdraw_ptx.output_witness(0), // output state note (output #0)
                 &zone_end.state,

--- a/goas/cl/cl/src/nullifier.rs
+++ b/goas/cl/cl/src/nullifier.rs
@@ -25,13 +25,13 @@ pub struct NullifierSecret(pub [u8; 16]);
 // can be provided to anyone wishing to transfer
 // you a note
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NullifierCommitment([u8; 32]);
+pub struct NullifierCommitment(pub [u8; 32]);
 
 // To allow users to maintain fewer nullifier secrets, we
 // provide a nonce to differentiate notes controlled by the same
 // secret. Each note is assigned a unique nullifier nonce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NullifierNonce([u8; 32]);
+pub struct NullifierNonce(pub [u8; 32]);
 
 // The nullifier attached to input notes to prove an input has not
 // already been spent.

--- a/goas/cl/cl/src/nullifier.rs
+++ b/goas/cl/cl/src/nullifier.rs
@@ -25,13 +25,13 @@ pub struct NullifierSecret(pub [u8; 16]);
 // can be provided to anyone wishing to transfer
 // you a note
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NullifierCommitment(pub [u8; 32]);
+pub struct NullifierCommitment([u8; 32]);
 
 // To allow users to maintain fewer nullifier secrets, we
 // provide a nonce to differentiate notes controlled by the same
 // secret. Each note is assigned a unique nullifier nonce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NullifierNonce(pub [u8; 32]);
+pub struct NullifierNonce([u8; 32]);
 
 // The nullifier attached to input notes to prove an input has not
 // already been spent.


### PR DESCRIPTION
This is to allow us to profile each proof individually (and just good to have)