### PR TITLE
Use efficient comm for balances

### DIFF
--- a/goas/atomic_asset_transfer/common/src/lib.rs
+++ b/goas/atomic_asset_transfer/common/src/lib.rs
@@ -12,11 +12,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
-// TODO: sparse merkle tree
-pub const MAX_BALANCES: usize = 1 << 8;
-pub const MAX_TXS: usize = 1 << 8;
-pub const MAX_EVENTS: usize = 1 << 8;
-
 // state of the zone
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub struct StateCommitment(pub [u8; 32]);


### PR DESCRIPTION
At the moment we're using merkle trees even though we don't need inclusion proofs, which means we're calculating more hashes than necessary and limiting the account set size to 256. This change is a temporary solution that chooses a more efficient way to calculate a commitment to the account balances, while we wait for something more scalable like a Verkle Tree.